### PR TITLE
Add GH workflow action to deploy to prod on release

### DIFF
--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -1,0 +1,43 @@
+name: Deploy to Firebase Functions on release (prod)
+'on':
+  push:
+    tags:
+      - 'v*'  # Triggers when a tag like v1.0.0 is pushed
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment:
+          - lszm_prod
+    environment: ${{ matrix.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+      - name: Install Google Cloud SDK components
+        run: |
+          sudo apt-get install google-cloud-cli
+
+      - name: Configure Google Cloud Project
+        run: |
+          gcloud config set project ${{ vars.FIREBASE_PROJECT }}
+
+      - name: Deploy Firebase Function (Go)
+        run: |
+          gcloud functions deploy cardPaymentsStripe \
+            --entry-point=CardPaymentsStripe \
+            --trigger-event=providers/google.firebase.database/eventTypes/ref.create \
+            --trigger-resource=projects/_/instances/${{ vars.FIREBASE_RTDB_NAME }}/refs/card-payments/{pushId} \
+            --runtime=go121 \
+            --set-env-vars=STRIPE_SECRET=${{ secrets.STRIPE_SECRET }},\
+          RETURN_BASE_URL=${{ vars.RETURN_BASE_URL }},\
+          WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }},\
+          WEBHOOK_URL=${{ vars.WEBHOOK_URL }},\
+          TERMINAL_ID=${{ vars.TERMINAL_ID }},\
+          FIREBASE_DATABASE_URL=https://${{ vars.FIREBASE_RTDB_NAME }}.firebaseio.com


### PR DESCRIPTION
- A release is done by creating a 'v*' tag (e.g. v1.0.0) on main (only trunk based deployment with one branch)
- Only enabled environment at this stage: lszm_prod