### PR TITLE
Set --no-gen2 for cloud function to be able to keep using rtdb triggers

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -35,6 +35,7 @@ jobs:
             --trigger-event=providers/google.firebase.database/eventTypes/ref.create \
             --trigger-resource=projects/_/instances/${{ vars.FIREBASE_RTDB_NAME }}/refs/card-payments/{pushId} \
             --runtime=go121 \
+            --no-gen2 \
             --set-env-vars=STRIPE_SECRET=${{ secrets.STRIPE_SECRET }},\
           RETURN_BASE_URL=${{ vars.RETURN_BASE_URL }},\
           WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }},\

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -35,6 +35,7 @@ jobs:
             --trigger-event=providers/google.firebase.database/eventTypes/ref.create \
             --trigger-resource=projects/_/instances/${{ vars.FIREBASE_RTDB_NAME }}/refs/card-payments/{pushId} \
             --runtime=go121 \
+            --no-gen2 \
             --set-env-vars=STRIPE_SECRET=${{ secrets.STRIPE_SECRET }},\
           RETURN_BASE_URL=${{ vars.RETURN_BASE_URL }},\
           WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }},\


### PR DESCRIPTION
Should fix this error during the deployment:

"As of this Cloud SDK release, new functions will be deployed as 2nd gen functions by default. This is equivalent to currently deploying new with the --gen2 flag. Existing 1st gen functions will not be impacted and will continue to deploy as 1st gen functions.
You can disable this behavior by explicitly specifying the --no-gen2 flag or by setting the functions/gen2 config property to 'off'. To learn more about the differences between 1st gen and 2nd gen functions, visit:
https://cloud.google.com/functions/docs/concepts/version-comparison"