### PR TITLE
Add lszi_test deploy environment

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -15,6 +15,7 @@ jobs:
           - lszo_test
           - lsze_test
           - lszt_test
+          - lszi_test
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Add `lszi_test` to the dev deploy matrix.

The lszi Firebase RTDB is in `europe-west1`, so no `FUNCTION_REGION` override is needed (defaults to `europe-west1`).

## Remaining setup (outside this repo)
- Create the `lszi_test` GitHub Environment with vars (`FIREBASE_PROJECT`, `FIREBASE_RTDB_NAME`, `FIREBASE_RTDB_URL`, `RETURN_BASE_URL`, `TERMINAL_ID`) and secrets (`STRIPE_SECRET`, `WEBHOOK_SECRET`, `GCP_SA_KEY` if not repo-level).
- Stripe restricted key perms per `docs/stripe-restricted-key-permissions.md`.
- Deploy once to get the `StripeWebhook` URL, register the Stripe webhook, then set `WEBHOOK_SECRET` and re-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)